### PR TITLE
Add helper method for time slot calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ out/
 gradle-app.setting
 !gradle-wrapper.jar
 .gradletasknamecache
+local.properties
 
 # Mac
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ var code3: String = timeBasedOneTimePasswordGenerator.generate(instant = java.ti
 
 Again, there is a helper method ```isValid(code: String, timestamp: Date)``` available in the instance of the generator, to make the validation of the received code possible in one line.
 
+There is also a helper method for calculating the time slot (counter) from a given timestamp, Date or Instant.
+```kotlin
+var counter0: Long = timeBasedOneTimePasswordGenerator.counter() // Will use System.currentTimeMillis()
+var counter1: Long = timeBasedOneTimePasswordGenerator.counter(timestamp = 1622234248000L)
+var counter2: Long = timeBasedOneTimePasswordGenerator.counter(date = java.util.Date(59)) // Will internally call counter(timestamp = date.time)
+var counter3: Long = timeBasedOneTimePasswordGenerator.counter(instant = java.time.Instant.ofEpochSecond(1622234248L)) // Will internally call counter(timestamp = instante.toEpochMillis())
+...
+```
+
+You can use this counter to calculate the start and the end of a timeslot and with this how long your TOTP is still valid.
+```kotlin
+val timestamp = instant.toEpochMillis()
+val totp = timeBasedOneTimePasswordGenerator.generate(timestamp)
+val counter = timeBasedOneTimePasswordGenerator.counter()
+val startEpochMillis = timeBasedOneTimePasswordGenerator.timeslotStart(counter)
+//basically the start of next time slot minus 1ms
+val endEpochMillis = timeBasedOneTimePasswordGenerator.timeslotStart(counter+1)-1
+//number of milliseconds the current TOTP is still valid
+val millisValid = endEpochMillis - timestamp
+```
 ### Google Authenticator
 
 ##### The "Google Way"

--- a/README.md
+++ b/README.md
@@ -112,12 +112,13 @@ val timeBasedOneTimePasswordGenerator = TimeBasedOneTimePasswordGenerator(secret
 
 As well as the HOTP configuration, the TOTP configuration takes the number of code digits and the HMAC algorithm as arguments (see the previous chapter). Additionally, the time window in which the generated code is valid is represented through the arguments timeStep and time step unit. The default value of the timestamp is the current system time
 
-The method ```generate(timestamp: Date)``` can now be used on the generator instance to generate a TOTP code:
+The methods ```generate(timestamp: Long)```, ```generate(date: Date)``` and ```generate(instant: Instant)``` can now be used on the generator instance to generate a TOTP code:
 
 ```kotlin
 var code0: String = timeBasedOneTimePasswordGenerator.generate() // Will use System.currentTimeMillis()
-var code1: String = timeBasedOneTimePasswordGenerator.generate(timestamp = Date(59))
-var code2: String = timeBasedOneTimePasswordGenerator.generate(timestamp = Date(1234567890))
+var code1: String = timeBasedOneTimePasswordGenerator.generate(timestamp = 1622234248000L)
+var code2: String = timeBasedOneTimePasswordGenerator.generate(date = java.util.Date(59)) // Will internally call generate(timestamp = date.time)
+var code3: String = timeBasedOneTimePasswordGenerator.generate(instant = java.time.Instant.ofEpochSecond(1622234248L)) // Will internally call generate(timestamp = instante.toEpochMillis())
 ...
 ```
 

--- a/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/TimeBasedOneTimePasswordGenerator.kt
+++ b/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/TimeBasedOneTimePasswordGenerator.kt
@@ -1,5 +1,6 @@
 package dev.turingcomplete.kotlinonetimepassword
 
+import java.time.Instant
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.math.floor
@@ -29,19 +30,22 @@ open class TimeBasedOneTimePasswordGenerator(private val secret: ByteArray, priv
    * steps is calculated. The default value is the current system time from
    * [System.currentTimeMillis].
    */
-  fun generate(timestamp: Date = Date(System.currentTimeMillis())): String {
+  fun generate(timestamp: Long = System.currentTimeMillis()): String {
 
     val counter = if (config.timeStep == 0L) {
       0 // To avoid a divide by zero exception
     }
     else {
-      floor((timestamp.time).toDouble()
+      floor(timestamp.toDouble()
                     .div(TimeUnit.MILLISECONDS.convert(config.timeStep, config.timeStepUnit).toDouble()))
               .toLong()
     }
 
     return hmacOneTimePasswordGenerator.generate(counter)
   }
+
+  fun generate(date: Date = Date(System.currentTimeMillis())) = generate(date.time)
+  fun generate(instant: Instant = Instant.now()) = generate(instant.toEpochMilli())
 
   /**
    * Validates the given code.
@@ -50,7 +54,10 @@ open class TimeBasedOneTimePasswordGenerator(private val secret: ByteArray, priv
    * @param timestamp the used challenge for the code. The default value is the
    *                  current system time from [System.currentTimeMillis].
    */
-  fun isValid(code: String, timestamp: Date = Date(System.currentTimeMillis())): Boolean {
+  fun isValid(code: String, timestamp: Long = System.currentTimeMillis()): Boolean {
     return code == generate(timestamp)
   }
+
+  fun isValid(code: String, date: Date = Date(System.currentTimeMillis())) = isValid(code, date.time)
+  fun isValid(code: String, instant: Instant = Instant.now()) = isValid(code, instant.toEpochMilli())
 }

--- a/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/TimeBasedOneTimePasswordGenerator.kt
+++ b/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/TimeBasedOneTimePasswordGenerator.kt
@@ -35,8 +35,21 @@ open class TimeBasedOneTimePasswordGenerator(private val secret: ByteArray, priv
       .toLong()
   }
 
-  fun counter(date: Date = Date(System.currentTimeMillis())):Long = counter(date.time)
-  fun counter(instant: Instant = Instant.now()):Long = counter(instant.toEpochMilli())
+  fun counter(date: Date):Long = counter(date.time)
+  fun counter(instant: Instant):Long = counter(instant.toEpochMilli())
+
+  /**
+   * Calculates the start of the given time slot.
+   *
+   * This is basically the reverse calculation of counter(timestamp) method.
+   *
+   * @param counter The counter representing the time slot.
+   * @return The Unix timestamp where the given time slot starts.
+   */
+  fun timeslotStart(counter:Long):Long {
+    val timeStepMillis = TimeUnit.MILLISECONDS.convert(config.timeStep, config.timeStepUnit).toDouble()
+    return (counter * timeStepMillis).toLong()
+  }
 
   /**
    * Generates a code representing the time-based one-time password.

--- a/src/test/kotlin/dev/turingcomplete/kotlinonetimepassword/TimeBasedOneTimePasswordGeneratorTest.kt
+++ b/src/test/kotlin/dev/turingcomplete/kotlinonetimepassword/TimeBasedOneTimePasswordGeneratorTest.kt
@@ -38,6 +38,27 @@ class TimeBasedOneTimePasswordGeneratorTest {
   }
 
   @Test
+  fun testTimeSlotCalculation() {
+    val hmacAlgorithm = HmacAlgorithm.SHA512
+    val config = TimeBasedOneTimePasswordConfig(30, TimeUnit.SECONDS, 9, hmacAlgorithm)
+    val secret = "Leia".toByteArray()
+    val timeBasedOneTimePasswordGenerator = TimeBasedOneTimePasswordGenerator(secret, config)
+
+    val timestamp = 1593727270000 // 2020/07/03 00:01:10 GMT+0200
+    val expectedCounter = 53124242L
+    val counter = timeBasedOneTimePasswordGenerator.counter(timestamp)
+    Assertions.assertEquals(expectedCounter, counter)
+
+    val expectedStart = 1593727260000L // 2020/07/03 00:01:00 GMT+0200
+    val startMillis = timeBasedOneTimePasswordGenerator.timeslotStart(counter)
+    Assertions.assertEquals(expectedStart, startMillis)
+
+    val expectedEnd = 1593727289000L // 2020/07/03 00:01:29 GMT+0200
+    val endMillis = (timeBasedOneTimePasswordGenerator.timeslotStart(counter+1)-1000)
+    Assertions.assertEquals(expectedEnd, endMillis)
+  }
+
+  @Test
   @DisplayName("Zero time step values")
   fun testZeroTimeStep() {
     val hmacAlgorithm = HmacAlgorithm.SHA1


### PR DESCRIPTION
Add a helper method to TimeBasedOneTimePasswordGenerator which calculates the start time of a given time slot (counter).
This is really helpful for calculating how long a generated TOTP is still valid.

This is based on PR #13