### PR TITLE
Remove Rogue `/`

### DIFF
--- a/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/OtpAuthUriBuilder.kt
+++ b/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/OtpAuthUriBuilder.kt
@@ -210,7 +210,7 @@ open class OtpAuthUriBuilder<S : OtpAuthUriBuilder<S>>(private val type: String,
 
   private fun buildUriWithoutSecret(additionalParameters: Map<String, String> = emptyMap()): String {
     val query = parameters.plus(additionalParameters).map { "${it.key}=${it.value}" }.joinToString(separator = "&", prefix = "?")
-    return "otpauth://$type/${if (label != null) "$label" else ""}$query"
+    return "otpauth://$type/${if (label != null) label else ""}$query"
   }
 
   private fun removePaddingFromBase32Secret(base32Secret: ByteArray): ByteArray {

--- a/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/OtpAuthUriBuilder.kt
+++ b/src/main/kotlin/dev/turingcomplete/kotlinonetimepassword/OtpAuthUriBuilder.kt
@@ -210,7 +210,7 @@ open class OtpAuthUriBuilder<S : OtpAuthUriBuilder<S>>(private val type: String,
 
   private fun buildUriWithoutSecret(additionalParameters: Map<String, String> = emptyMap()): String {
     val query = parameters.plus(additionalParameters).map { "${it.key}=${it.value}" }.joinToString(separator = "&", prefix = "?")
-    return "otpauth://$type/${if (label != null) "$label/" else ""}$query"
+    return "otpauth://$type/${if (label != null) "$label" else ""}$query"
   }
 
   private fun removePaddingFromBase32Secret(base32Secret: ByteArray): ByteArray {

--- a/src/test/kotlin/dev/turingcomplete/kotlinonetimepassword/OtpAuthUriBuilderTest.kt
+++ b/src/test/kotlin/dev/turingcomplete/kotlinonetimepassword/OtpAuthUriBuilderTest.kt
@@ -89,17 +89,17 @@ class OtpAuthUriBuilderTest {
 
   @Test
   fun testLabel() {
-    assertEquals("otpauth://totp/iss:acc/?secret=$BASE32_SECRET_REMOVED_PADDING",
+    assertEquals("otpauth://totp/iss:acc?secret=$BASE32_SECRET_REMOVED_PADDING",
                  OtpAuthUriBuilder.forTotp(BASE32_SECRET)
                    .label("acc", "iss", false)
                    .buildToString())
 
-    assertEquals("otpauth://totp/acc/?secret=$BASE32_SECRET_REMOVED_PADDING",
+    assertEquals("otpauth://totp/acc?secret=$BASE32_SECRET_REMOVED_PADDING",
                  OtpAuthUriBuilder.forTotp(BASE32_SECRET)
                    .label("acc", null, false)
                    .buildToString())
 
-    assertEquals("otpauth://totp/iss%3Aacc/?secret=$BASE32_SECRET_REMOVED_PADDING",
+    assertEquals("otpauth://totp/iss%3Aacc?secret=$BASE32_SECRET_REMOVED_PADDING",
                  OtpAuthUriBuilder.forTotp(BASE32_SECRET)
                    .label("acc", "iss", true)
                    .buildToString())
@@ -107,7 +107,7 @@ class OtpAuthUriBuilderTest {
 
   @Test
   fun testLabelUrlEncoding() {
-    assertEquals("otpauth://totp/i%2F%2Fss%3Aa%2F%2Fcc/?secret=$BASE32_SECRET_REMOVED_PADDING",
+    assertEquals("otpauth://totp/i%2F%2Fss%3Aa%2F%2Fcc?secret=$BASE32_SECRET_REMOVED_PADDING",
                  OtpAuthUriBuilder.forTotp(BASE32_SECRET)
                    .label("a//cc", "i//ss", true)
                    .buildToString())
@@ -121,7 +121,7 @@ class OtpAuthUriBuilderTest {
       .digits(8)
 
     val stringRepresentation = builder.buildToString()
-    assertEquals("otpauth://totp/i%2Fss:acc/?issuer=i%2Fss&digits=8&secret=$BASE32_SECRET_REMOVED_PADDING", stringRepresentation)
+    assertEquals("otpauth://totp/i%2Fss:acc?issuer=i%2Fss&digits=8&secret=$BASE32_SECRET_REMOVED_PADDING", stringRepresentation)
 
     val byteArrayRepresentation = builder.buildToByteArray()
     assertEquals(stringRepresentation, String(byteArrayRepresentation))


### PR DESCRIPTION
#  Rogue `/` Appears at the End of the `label`

There is a `/` that is appended at the end of the `label`. As a result, in the authenticator apps, `label` ends with `/`.

For the `URI` generated using this below:
```kotlin
import dev.turingcomplete.kotlinonetimepassword.OtpAuthUriBuilder
import org.apache.commons.codec.binary.Base32

fun main() {
    val authURI = OtpAuthUriBuilder.forTotp(Base32().encode("secret".toByteArray()))
        .label("John", "Company")
        .issuer("Company")
        .digits(8)
        .buildToString()

    println(authURI)
}
``` 

Generated URI: `otpauth://totp/Company:John/?issuer Company&digits=8&secret=ONSWG4TFOQ`

After scanning the QR code generated using the above `URI` the key entry as seen on the authenticator app (Google Authenticator):
![Screenshot from 2024-04-13 23-07-11](https://github.com/marcelkliemannel/kotlin-onetimepassword/assets/67045923/d4e69f33-56e1-40f9-9852-43dc9752ac01)

This PR fixes this bug.
